### PR TITLE
Add theme toggle and polished effects

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -18,6 +18,9 @@ const { title, description, image = '/blog-placeholder-1.jpg' } = Astro.props;
 <!-- Global Metadata -->
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
+<meta name="color-scheme" content="light dark" />
+<meta name="theme-color" content="#fafafa" media="(prefers-color-scheme: light)" />
+<meta name="theme-color" content="#1e1e20" media="(prefers-color-scheme: dark)" />
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 <link rel="sitemap" href="/sitemap-index.xml" />
 <link
@@ -53,3 +56,19 @@ const { title, description, image = '/blog-placeholder-1.jpg' } = Astro.props;
 <meta property="twitter:title" content={title} />
 <meta property="twitter:description" content={description} />
 <meta property="twitter:image" content={new URL(image, Astro.url)} />
+
+<!-- Theme toggle script -->
+<script>
+    (function () {
+        const root = document.documentElement;
+        const stored = localStorage.getItem('theme');
+        if (stored) {
+            root.dataset.theme = stored;
+        }
+        window.toggleTheme = function () {
+            const newTheme = root.dataset.theme === 'dark' ? 'light' : 'dark';
+            root.dataset.theme = newTheme;
+            localStorage.setItem('theme', newTheme);
+        };
+    })();
+</script>

--- a/src/components/BentoGrid.astro
+++ b/src/components/BentoGrid.astro
@@ -1,0 +1,19 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import FormattedDate from './FormattedDate.astro';
+interface Props {
+    posts: CollectionEntry<'blog'>[];
+}
+const { posts } = Astro.props;
+---
+<div class="bento-grid">
+    {posts.map(post => (
+        <a href={`/blog/${post.id}/`} class="bento-item">
+            <img src={post.data.heroImage} alt={post.data.title} loading="lazy" />
+            <div class="bento-info">
+                <h3>{post.data.title}</h3>
+                <p class="bento-date"><FormattedDate date={post.data.pubDate} /></p>
+            </div>
+        </a>
+    ))}
+</div>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -18,24 +18,54 @@ import { SITE_TITLE } from '../consts';
 		</div>
 		
 		
-		<button class="mobile-menu-toggle" aria-label="Toggle menu">
-			<span></span>
-			<span></span>
-			<span></span>
-		</button>
+                <button class="theme-toggle" aria-label="Toggle theme" onclick="toggleTheme()">
+                        <svg class="sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <circle cx="12" cy="12" r="5" />
+                                <g stroke-linecap="round">
+                                        <line x1="12" y1="1" x2="12" y2="3" />
+                                        <line x1="12" y1="21" x2="12" y2="23" />
+                                        <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+                                        <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+                                        <line x1="1" y1="12" x2="3" y2="12" />
+                                        <line x1="21" y1="12" x2="23" y2="12" />
+                                        <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+                                        <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+                                </g>
+                        </svg>
+                        <svg class="moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                <path d="M21 12.79A9 9 0 1111.21 3a7 7 0 009.79 9.79z" />
+                        </svg>
+                </button>
+
+                <button class="mobile-menu-toggle" aria-label="Toggle menu">
+                        <span></span>
+                        <span></span>
+                        <span></span>
+                </button>
 	</nav>
 </header>
 
 <style>
-	.header {
-		position: sticky;
-		top: 0;
-		z-index: 100;
-		background: rgba(255, 255, 255, 0.8);
-		backdrop-filter: blur(20px);
-		border-bottom: 1px solid rgba(var(--gray), 0.1);
-		box-shadow: var(--shadow-sm);
-	}
+        .header {
+                position: sticky;
+                top: 0;
+                z-index: 100;
+                background: rgba(255, 255, 255, 0.8);
+                backdrop-filter: blur(20px);
+                border-bottom: 1px solid rgba(var(--gray), 0.1);
+                box-shadow: var(--shadow-sm);
+                background-image: linear-gradient(90deg,
+                        rgba(var(--accent-rgb), 0.08) 0%,
+                        rgba(var(--accent-light-rgb), 0.08) 100%);
+                background-size: 200% 100%;
+                animation: headerGradient 12s ease infinite;
+        }
+
+        @keyframes headerGradient {
+                0% { background-position: 0% 50%; }
+                50% { background-position: 100% 50%; }
+                100% { background-position: 0% 50%; }
+        }
 	
 	.nav {
 		display: flex;
@@ -65,13 +95,37 @@ import { SITE_TITLE } from '../consts';
 		transform: translateY(-1px);
 	}
 	
-	.nav-links {
-		display: flex;
-		align-items: center;
-		gap: 2rem;
-		flex: 1;
-		justify-content: center;
-	}
+        .nav-links {
+                display: flex;
+                align-items: center;
+                gap: 2rem;
+                flex: 1;
+                justify-content: center;
+        }
+
+        .theme-toggle {
+                background: none;
+                border: none;
+                cursor: pointer;
+                display: flex;
+                align-items: center;
+                padding: 0.5rem;
+                color: rgb(var(--gray-dark));
+                transition: transform 0.2s ease;
+                margin-left: auto;
+        }
+
+        .theme-toggle:hover {
+                transform: scale(1.1);
+        }
+
+        .theme-toggle svg {
+                width: 20px;
+                height: 20px;
+        }
+
+        html[data-theme='dark'] .theme-toggle .sun { display: none; }
+        html:not([data-theme='dark']) .theme-toggle .moon { display: none; }
 	
 	.mobile-menu-toggle {
 		display: none;

--- a/src/components/MagicButton.astro
+++ b/src/components/MagicButton.astro
@@ -1,0 +1,14 @@
+---
+interface Props {
+    href: string;
+    text: string;
+    secondary?: boolean;
+}
+const { href, text, secondary = false } = Astro.props;
+---
+<a href={href} class={`magic-btn${secondary ? ' magic-btn-secondary' : ''}`}>
+    {text}
+    <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+        <path d="M5 12h14M12 5l7 7-7 7" fill="none" stroke="currentColor" stroke-width="2"/>
+    </svg>
+</a>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,6 +5,8 @@ import Footer from '../components/Footer.astro';
 import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
 import { getCollection } from 'astro:content';
 import FormattedDate from '../components/FormattedDate.astro';
+import MagicButton from '../components/MagicButton.astro';
+import BentoGrid from '../components/BentoGrid.astro';
 
 const posts = (await getCollection('blog')).sort(
 	(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
@@ -30,10 +32,10 @@ const posts = (await getCollection('blog')).sort(
 					I write about technology, programming, and life experiences. 
 					Join me as I share insights and stories from my journey.
 				</p>
-				<div class="hero-actions slide-up">
-					<a href="/blog" class="btn">Read My Posts</a>
-					<a href="/about" class="btn btn-secondary">About Me</a>
-				</div>
+                                <div class="hero-actions slide-up">
+                                        <MagicButton href="/blog" text="Read My Posts" />
+                                        <MagicButton href="/about" text="About Me" secondary={true} />
+                                </div>
 			</div>
 		</section>
 
@@ -45,35 +47,11 @@ const posts = (await getCollection('blog')).sort(
 					<p>My latest thoughts and writings</p>
 				</div>
 				
-				<div class="grid grid-3">
-					{posts.map((post) => (
-						<article class="card post-card fade-in">
-							<div class="post-image">
-								<img src={post.data.heroImage} alt={post.data.title} loading="lazy" />
-							</div>
-							<div class="post-content">
-								<div class="post-meta">
-									<FormattedDate date={post.data.pubDate} />
-								</div>
-								<h3 class="post-title">
-									<a href={`/blog/${post.id}/`} class="no-underline">{post.data.title}</a>
-								</h3>
-								<p class="post-excerpt">{post.data.description}</p>
-								<a href={`/blog/${post.id}/`} class="read-more">
-									Read More
-									<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-										<path d="M5 12h14"/>
-										<path d="M12 5l7 7-7 7"/>
-									</svg>
-								</a>
-							</div>
-						</article>
-					))}
-				</div>
+                                <BentoGrid posts={posts} />
 				
-				<div class="section-cta">
-					<a href="/blog" class="btn">View All Articles</a>
-				</div>
+                                <div class="section-cta">
+                                        <MagicButton href="/blog" text="View All Articles" />
+                                </div>
 			</div>
 		</section>
 
@@ -121,80 +99,6 @@ const posts = (await getCollection('blog')).sort(
 		background: rgba(var(--gray-light), 0.3);
 	}
 	
-	.post-card {
-		overflow: hidden;
-		padding: 0;
-		transition: all 0.3s ease;
-	}
-	
-	.post-card:hover {
-		transform: translateY(-8px);
-	}
-	
-	.post-image {
-		position: relative;
-		overflow: hidden;
-		aspect-ratio: 16/9;
-	}
-	
-	.post-image img {
-		width: 100%;
-		height: 100%;
-		object-fit: cover;
-		transition: transform 0.3s ease;
-		border-radius: 0;
-	}
-	
-	.post-card:hover .post-image img {
-		transform: scale(1.05);
-	}
-	
-	.post-content {
-		padding: 1.5rem;
-	}
-	
-	.post-meta {
-		font-size: 0.875rem;
-		color: rgb(var(--gray));
-		margin-bottom: 0.75rem;
-	}
-	
-	.post-title {
-		margin-bottom: 0.75rem;
-		font-size: 1.125rem;
-		line-height: 1.4;
-	}
-	
-	.post-title a {
-		color: rgb(var(--black));
-		transition: color 0.2s ease;
-	}
-	
-	.post-title a:hover {
-		color: var(--accent);
-	}
-	
-	.post-excerpt {
-		color: rgb(var(--gray));
-		font-size: 0.875rem;
-		line-height: 1.6;
-		margin-bottom: 1rem;
-	}
-	
-	.read-more {
-		display: inline-flex;
-		align-items: center;
-		gap: 0.5rem;
-		color: var(--accent);
-		font-weight: 500;
-		font-size: 0.875rem;
-		transition: all 0.2s ease;
-	}
-	
-	.read-more:hover {
-		gap: 0.75rem;
-		color: var(--accent-dark);
-	}
 	
 	/* Animations */
 	@keyframes fadeInUp {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -5,9 +5,11 @@
 
 :root {
 	/* Primary colors */
-	--accent: #5e6ad2;
-	--accent-dark: #4c5bc7;
-	--accent-light: #7c88db;
+        --accent: #5e6ad2;
+        --accent-dark: #4c5bc7;
+        --accent-light: #7c88db;
+        --accent-rgb: 94, 106, 210;
+        --accent-light-rgb: 124, 136, 219;
 	
 	/* Neutral colors */
 	--black: 8, 8, 11;
@@ -130,13 +132,20 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 h1 {
-	font-size: clamp(2.5rem, 5vw, 4rem);
-	font-weight: 700;
-	background: linear-gradient(135deg, rgb(var(--black)) 0%, var(--accent) 100%);
-	-webkit-background-clip: text;
-	-webkit-text-fill-color: transparent;
-	background-clip: text;
-	margin-bottom: 1.5rem;
+        font-size: clamp(2.5rem, 5vw, 4rem);
+        font-weight: 700;
+        background: linear-gradient(135deg, rgb(var(--black)) 0%, var(--accent) 100%);
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+        background-clip: text;
+        background-size: 200% 100%;
+        animation: textGradient 8s linear infinite;
+        margin-bottom: 1.5rem;
+}
+
+@keyframes textGradient {
+        0%, 100% { background-position: 0% 50%; }
+        50% { background-position: 100% 50%; }
 }
 
 h2 {
@@ -182,27 +191,28 @@ a:not(.no-underline):hover::after {
 
 /* Buttons */
 .btn {
-	display: inline-flex;
-	align-items: center;
-	gap: 0.5rem;
-	padding: 0.75rem 1.5rem;
-	background: var(--accent);
-	color: white;
-	border: none;
-	border-radius: var(--radius-md);
-	font-weight: 500;
-	font-size: 0.875rem;
-	cursor: pointer;
-	transition: all 0.2s ease;
-	text-decoration: none;
-	box-shadow: var(--shadow-sm);
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        padding: 0.75rem 1.5rem;
+        background-image: linear-gradient(90deg, var(--accent) 0%, var(--accent-light) 100%);
+        background-size: 200% 100%;
+        color: white;
+        border: none;
+        border-radius: var(--radius-md);
+        font-weight: 500;
+        font-size: 0.875rem;
+        cursor: pointer;
+        transition: all 0.3s ease;
+        text-decoration: none;
+        box-shadow: var(--shadow-sm);
 }
 
 .btn:hover {
-	background: var(--accent-dark);
-	transform: translateY(-1px);
-	box-shadow: var(--shadow-md);
-	color: white;
+        background-position: right center;
+        transform: translateY(-1px);
+        box-shadow: var(--shadow-md);
+        color: white;
 }
 
 .btn-secondary {
@@ -243,7 +253,7 @@ a:not(.no-underline):hover::after {
 .card:hover {
 	transform: translateY(-4px);
 	box-shadow: var(--shadow-xl);
-	border-color: rgba(var(--accent), 0.3);
+        border-color: rgba(var(--accent-rgb), 0.3);
 }
 
 /* Grid layouts */
@@ -262,9 +272,37 @@ a:not(.no-underline):hover::after {
 
 /* Hero section */
 .hero {
-	text-align: center;
-	padding: 4rem 0 6rem;
-	position: relative;
+        text-align: center;
+        padding: 4rem 0 6rem;
+        position: relative;
+}
+
+.hero::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: radial-gradient(circle at 50% -20%, rgba(var(--accent-rgb), 0.2), transparent 70%);
+        z-index: -1;
+        animation: heroPulse 10s ease-in-out infinite;
+}
+
+.hero::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: conic-gradient(from 180deg at 50% 50%, rgba(var(--accent-rgb), 0.15), transparent 30%);
+        z-index: -2;
+        animation: rotateGradient 30s linear infinite;
+}
+
+@keyframes rotateGradient {
+        from { transform: rotate(0deg); }
+        to { transform: rotate(360deg); }
+}
+
+@keyframes heroPulse {
+        0%, 100% { transform: scale(1); opacity: 0.8; }
+        50% { transform: scale(1.1); opacity: 1; }
 }
 
 .hero-content {
@@ -326,7 +364,7 @@ blockquote {
 	border-left: 4px solid var(--accent);
 	padding: 1rem 0 1rem 1.5rem;
 	margin: 2rem 0;
-	background: rgba(var(--accent), 0.05);
+        background: rgba(var(--accent-rgb), 0.05);
 	border-radius: 0 var(--radius-md) var(--radius-md) 0;
 	font-style: italic;
 	position: relative;
@@ -361,7 +399,7 @@ th, td {
 }
 
 th {
-	background: rgba(var(--accent), 0.1);
+        background: rgba(var(--accent-rgb), 0.1);
 	font-weight: 600;
 	color: rgb(var(--black));
 }
@@ -456,3 +494,146 @@ li {
 .mt-2 { margin-top: 1rem; }
 .mt-3 { margin-top: 1.5rem; }
 .mt-4 { margin-top: 2rem; }
+
+/* Dark mode styling */
+@media (prefers-color-scheme: dark) {
+       :root {
+               --accent: #8b9eff;
+               --accent-dark: #6f85f2;
+               --accent-light: #aab6ff;
+               --accent-rgb: 139, 158, 255;
+               --accent-light-rgb: 170, 182, 255;
+
+               --black: 255, 255, 255;
+               --gray: 200, 200, 205;
+               --gray-light: 60, 60, 65;
+               --gray-dark: 220, 220, 230;
+               --gray-darker: 30, 30, 32;
+
+               --bg-gradient: linear-gradient(135deg,
+                               rgba(50, 56, 100, 0.4) 0%,
+                               rgba(40, 48, 84, 0.4) 100%);
+               --hero-gradient: radial-gradient(ellipse 80% 50% at 50% -20%,
+                               rgba(94, 106, 210, 0.25) 0%,
+                               transparent 60%);
+               --card-gradient: linear-gradient(135deg,
+                               rgba(255, 255, 255, 0.05) 0%,
+                               rgba(255, 255, 255, 0.02) 100%);
+       }
+
+       body {
+               background: rgb(var(--gray-darker));
+               background-image: var(--bg-gradient);
+               color: rgb(var(--gray-dark));
+       }
+
+       .card {
+               background: var(--card-gradient);
+               border-color: rgba(255, 255, 255, 0.1);
+       }
+}
+
+:root[data-theme='dark'] {
+       --accent: #8b9eff;
+       --accent-dark: #6f85f2;
+       --accent-light: #aab6ff;
+       --accent-rgb: 139, 158, 255;
+       --accent-light-rgb: 170, 182, 255;
+
+       --black: 255, 255, 255;
+       --gray: 200, 200, 205;
+       --gray-light: 60, 60, 65;
+       --gray-dark: 220, 220, 230;
+       --gray-darker: 30, 30, 32;
+
+       --bg-gradient: linear-gradient(135deg,
+                       rgba(50, 56, 100, 0.4) 0%,
+                       rgba(40, 48, 84, 0.4) 100%);
+       --hero-gradient: radial-gradient(ellipse 80% 50% at 50% -20%,
+                       rgba(94, 106, 210, 0.25) 0%,
+                       transparent 60%);
+       --card-gradient: linear-gradient(135deg,
+                       rgba(255, 255, 255, 0.05) 0%,
+                       rgba(255, 255, 255, 0.02) 100%);
+}
+
+body[data-theme='dark'] {
+       background: rgb(var(--gray-darker));
+       background-image: var(--bg-gradient);
+       color: rgb(var(--gray-dark));
+}
+
+body[data-theme='dark'] .card {
+       background: var(--card-gradient);
+       border-color: rgba(255, 255, 255, 0.1);
+}
+/* Magic UI Buttons */
+.magic-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.75rem 1.5rem;
+    position: relative;
+    font-weight: 500;
+    font-size: 0.875rem;
+    color: var(--accent);
+    border-radius: var(--radius-md);
+    overflow: hidden;
+    transition: color 0.3s ease;
+}
+.magic-btn::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(90deg, var(--accent) 0%, var(--accent-light) 100%);
+    opacity: 0.15;
+    transition: opacity 0.3s ease;
+}
+.magic-btn:hover::before {
+    opacity: 0.3;
+}
+.magic-btn svg { transition: transform 0.3s ease; }
+.magic-btn:hover svg { transform: translateX(2px); }
+.magic-btn-secondary {
+    color: rgb(var(--gray-dark));
+}
+
+/* Bento Grid Layout */
+.bento-grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+.bento-item {
+    position: relative;
+    overflow: hidden;
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-md);
+    background: var(--card-gradient);
+    backdrop-filter: blur(10px);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    text-decoration: none;
+    color: inherit;
+}
+.bento-item:hover {
+    transform: translateY(-4px) scale(1.02);
+    box-shadow: var(--shadow-xl);
+}
+.bento-item img {
+    width: 100%;
+    height: 160px;
+    object-fit: cover;
+    border-bottom: 1px solid rgba(var(--gray), 0.1);
+}
+.bento-info {
+    padding: 1rem;
+}
+.bento-info h3 {
+    margin: 0 0 0.5rem;
+    font-size: 1rem;
+    color: rgb(var(--black));
+}
+.bento-date {
+    font-size: 0.75rem;
+    color: rgb(var(--gray));
+}


### PR DESCRIPTION
## Summary
- introduce a theme toggle with localStorage persistence
- animate the hero background with a rotating conic gradient
- enhance post cards with glassy styling and hover effects
- apply explicit dark-theme variables for manual mode

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c25fdb260832c9d9e3358caa4e786